### PR TITLE
Update candle info text

### DIFF
--- a/lib/src/widgets/candle_info_text.dart
+++ b/lib/src/widgets/candle_info_text.dart
@@ -20,15 +20,11 @@ class CandleInfoText extends StatelessWidget {
     return "${value < 10 ? 0 : ""}$value";
   }
 
-  String dateFormatter(DateTime date) {
-    return "${date.year}-${numberFormat(date.month)}-${numberFormat(date.day)} ${numberFormat(date.hour)}:${numberFormat(date.minute)}";
-  }
-
   @override
   Widget build(BuildContext context) {
     return RichText(
       text: TextSpan(
-        text: dateFormatter(candle.date),
+        text: "",
         style: defaultStyle,
         children: <TextSpan>[
           TextSpan(text: " O:"),
@@ -55,6 +51,20 @@ class CandleInfoText extends StatelessWidget {
           TextSpan(text: " C:"),
           TextSpan(
             text: HelperFunctions.priceToString(candle.close),
+            style: TextStyle(
+              color: candle.isBull ? bullColor : bearColor,
+            ),
+          ),
+          TextSpan(text: " "),
+          TextSpan(
+            text: HelperFunctions.priceToString(candle.close - candle.open),
+            style: TextStyle(
+              color: candle.isBull ? bullColor : bearColor,
+            ),
+          ),
+          TextSpan(text: " "),
+          TextSpan(
+            text: "(" + ((candle.close - candle.open) / candle.open * 100).toStringAsFixed(2) + "%)",
             style: TextStyle(
               color: candle.isBull ? bullColor : bearColor,
             ),


### PR DESCRIPTION
Redundant date time is removed and absolute and relative (%) variation of a candle info is displayed.

PD: Please, verify absolute is correctly computed since I tested with binance real data and differs slightly on mobile.